### PR TITLE
Update compile.sh

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -47,10 +47,7 @@ fi
 pushd $BUILD_DIR
 
 # start with no tests
-export GYP_DEFINES='build_with_chromium=0 \
-                    include_tests=0 \
-                    disable_glibcxx_debug=1 \
-                    linux_use_debug_fission=0'
+export GYP_DEFINES='build_with_chromium=0 include_tests=0 disable_glibcxx_debug=1 linux_use_debug_fission=0'
 
 if [ $UNAME = 'Windows' ]; then
   export DEPOT_TOOLS_WIN_TOOLCHAIN=0


### PR DESCRIPTION
Backslashes in string make compile.sh fail on Ubuntu 14.04.3 LTS (EC2 instance). Landmines.py will throw error @ shlex.split(os.environ.get('GYP_DEFINES', ''))

Simple fix.
